### PR TITLE
feature/US-007B-BE-Definir-modelo-de-datos-de-ejecucion-de-ruta

### DIFF
--- a/src/main/java/com/fitnessapp/fitapp_api/routeexecution/model/RouteExecution.java
+++ b/src/main/java/com/fitnessapp/fitapp_api/routeexecution/model/RouteExecution.java
@@ -1,0 +1,88 @@
+package com.fitnessapp.fitapp_api.routeexecution.model;
+
+import com.fitnessapp.fitapp_api.auth.model.UserAuth;
+import com.fitnessapp.fitapp_api.route.model.Route;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(
+        name = "route_executions"
+)
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class RouteExecution {
+
+    @EqualsAndHashCode.Include
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "route_id", nullable = false, foreignKey = @ForeignKey(name = "fk_route_execution_route"))
+    private Route route;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_route_execution_user"))
+    private UserAuth user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RouteExecutionStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = true)
+    private ActivityType activityType;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(name = "pause_time", nullable = true)
+    private LocalDateTime pauseTime;
+
+    @Column(name = "end_time", nullable = true)
+    private LocalDateTime endTime;
+
+    @Column(name = "total_paused_time_sec", nullable = false)
+    private Long totalPausedTimeSec = 0L;
+
+    @Column(name = "duration_sec", nullable = true)
+    private Long durationSec;
+
+    @Column(name = "calories", precision = 10, scale = 2, nullable = true)
+    private BigDecimal calories;
+
+    @Column(name = "notes", length = 500)
+    private String notes;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    // -------------------
+    // Enums internos
+    // -------------------
+    public enum RouteExecutionStatus {
+        IN_PROGRESS,
+        PAUSED,
+        FINISHED
+    }
+
+    public enum ActivityType {
+        WALK,
+        RUN,
+        BIKE
+    }
+}

--- a/src/main/resources/db/migration/V4__routeExecution.sql
+++ b/src/main/resources/db/migration/V4__routeExecution.sql
@@ -1,0 +1,25 @@
+set NAMES utf8mb4;
+
+CREATE TABLE route_executions (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    route_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    status ENUM('IN_PROGRESS', 'PAUSED', 'FINISHED') NOT NULL,
+    start_time TIMESTAMP NOT NULL,
+    pause_time TIMESTAMP NULL,
+    end_time TIMESTAMP NULL,
+    total_paused_time_sec BIGINT NOT NULL DEFAULT 0,
+    duration_sec BIGINT NULL,
+    activity_type ENUM('WALK', 'RUN', 'BIKE') NULL,
+    calories DECIMAL(10,2) NULL,
+    notes VARCHAR(500) NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_route_execution_route FOREIGN KEY (route_id)
+      REFERENCES routes(id)
+      ON DELETE CASCADE,
+    CONSTRAINT fk_route_execution_user FOREIGN KEY (user_id)
+      REFERENCES user_auth(id)
+      ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
### [US-007B][BE] Definir modelo de datos de ejecución de ruta

**Contexto:**  
Se implementa el modelo `RouteExecution` y su correspondiente migración SQL para registrar las ejecuciones de rutas realizadas por los usuarios, incluyendo el control de tiempos, estados y cálculo de calorías al finalizar.

**Cambios realizados:**  
- **`route/model/RouteExecution.java`**:  
  Creado el modelo JPA con relaciones hacia `UserAuth` y `Route`.  
  Incluye los campos:
  - `status` (`IN_PROGRESS`, `PAUSED`, `FINISHED`)
  - `startTime`, `pauseTime`, `endTime`
  - `totalPausedTimeSec`, `durationSec`
  - `activityType` (`WALK`, `RUN`, `BIKE`)
  - `calories`, `notes`
  
- **Migración `V4__routeExecutions.sql`**:  
  Creada tabla `route_executions` con:
  - Claves foráneas hacia `routes` y `user_auth`
  - Restricciones `ENUM` para estado y tipo de actividad  
  - Auditoría `created_at`, `updated_at`  
  - Eliminación en cascada al borrar usuario o ruta

**Criterios de aceptación:**
- Relaciones correctas con `user_auth` y `routes`.
- Estados limitados a `IN_PROGRESS`, `PAUSED`, `FINISHED`.
- Campos de tiempo coherentes (`start_time`, `end_time`, `total_paused_time_sec`, `duration_sec`).