### PR TITLE
fix(home): Prevenir NullPointerException al calcular KPIs

### DIFF
--- a/src/main/java/com/fitnessapp/fitapp_api/home/service/implementation/HomeServiceImpl.java
+++ b/src/main/java/com/fitnessapp/fitapp_api/home/service/implementation/HomeServiceImpl.java
@@ -43,8 +43,10 @@ public class HomeServiceImpl implements HomeService {
         LocalDate today = LocalDate.now();
 
         List<RouteExecution> todaysCompletedRoutes = routesExecutions.stream()
-                .filter(routeExecution -> routeExecution.getEndTime().toLocalDate().equals(today))
+                // 1. Filtrar por estado FINALIZADO primero
                 .filter(routeExecution -> routeExecution.getStatus() == RouteExecution.RouteExecutionStatus.FINISHED)
+                // 2. Ahora es seguro llamar a getEndTime(), porque las rutas finalizadas lo tienen
+                .filter(routeExecution -> routeExecution.getEndTime().toLocalDate().equals(today))
                 .toList();
         int routesCompleted = todaysCompletedRoutes.size();
         long totalDurationSec = todaysCompletedRoutes.stream()
@@ -54,6 +56,9 @@ public class HomeServiceImpl implements HomeService {
                 .mapToDouble(routeExecution -> routeExecution.getRoute().getDistanceKm().doubleValue())
                 .sum();
         double totalCalories = todaysCompletedRoutes.stream()
+                // 1. Asegurarse de que las calorías no sean nulas antes de sumar
+                .filter(routeExecution -> routeExecution.getCalories() != null)
+                // 2. Ahora es seguro llamar a .doubleValue()
                 .mapToDouble(routeExecution -> routeExecution.getCalories().doubleValue())
                 .sum();
 


### PR DESCRIPTION
Corrige un error 500 que ocurría al llamar a `GET /api/v1/home/kpis/today` mientras una ejecución de ruta estaba en estado `IN_PROGRESS`.

El `HomeServiceImpl` intentaba acceder a `getEndTime()` en ejecuciones que aún eran nulas, causando un `NullPointerException`.

Se invierte el orden de los filtros para comprobar `STATUS == FINISHED` antes de acceder a `getEndTime()`. Se añade también una comprobación de nulidad al sumar las calorías.