### PR TITLE
fix: corregir bug del cronómetro, optimizar KPIs y blindar ejecución de rutas

### DIFF
--- a/src/main/java/com/fitnessapp/fitapp_api/home/service/implementation/HomeServiceImpl.java
+++ b/src/main/java/com/fitnessapp/fitapp_api/home/service/implementation/HomeServiceImpl.java
@@ -15,8 +15,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -45,28 +47,32 @@ public class HomeServiceImpl implements HomeService {
         List<RouteExecution> todaysCompletedRoutes = routesExecutions.stream()
                 // 1. Filtrar por estado FINALIZADO primero
                 .filter(routeExecution -> routeExecution.getStatus() == RouteExecution.RouteExecutionStatus.FINISHED)
+                .filter(routeExecution -> routeExecution.getEndTime() != null)
                 // 2. Ahora es seguro llamar a getEndTime(), porque las rutas finalizadas lo tienen
                 .filter(routeExecution -> routeExecution.getEndTime().toLocalDate().equals(today))
                 .toList();
         int routesCompleted = todaysCompletedRoutes.size();
         long totalDurationSec = todaysCompletedRoutes.stream()
-                .mapToLong(RouteExecution::getDurationSec)
+                .mapToLong(routeExecution -> routeExecution.getDurationSec() != null ? routeExecution.getDurationSec() : 0L)
                 .sum();
         double totalDistanceKm = todaysCompletedRoutes.stream()
+                .filter(routeExecution -> routeExecution.getRoute() != null) // <--- Proteger contra rutas borradas
                 .mapToDouble(routeExecution -> routeExecution.getRoute().getDistanceKm().doubleValue())
                 .sum();
+
         double totalCalories = todaysCompletedRoutes.stream()
-                // 1. Asegurarse de que las calorías no sean nulas antes de sumar
                 .filter(routeExecution -> routeExecution.getCalories() != null)
-                // 2. Ahora es seguro llamar a .doubleValue()
                 .mapToDouble(routeExecution -> routeExecution.getCalories().doubleValue())
                 .sum();
 
         int activeStreak = calculateActiveStreak(routesExecutions);
 
-        List<Route> routes = routeRepository.findAllByUserEmail(email).stream()
-                .filter(route -> route.getCreatedAt().toLocalDate().equals(today))
-                .toList();
+        // Consultamos a la BD directamente en lugar de traer toda la lista
+        boolean hasCreatedRoutes = routeRepository.existsByUser_EmailAndCreatedAtBetween(
+                email,
+                today.atStartOfDay(),
+                today.atTime(LocalTime.MAX)
+        );
 
         return new HomeKpisTodayResponseDTO(
                 routesCompleted,
@@ -74,14 +80,16 @@ public class HomeServiceImpl implements HomeService {
                 totalDistanceKm,
                 totalCalories,
                 activeStreak,
-                !routes.isEmpty()
+                hasCreatedRoutes
         );
     }
 
     private int calculateActiveStreak(List<RouteExecution> completedRoutes) {
         List<LocalDate> completionDates = completedRoutes.stream()
                 .filter(routeExecution -> routeExecution.getStatus() == RouteExecution.RouteExecutionStatus.FINISHED)
-                .map(routeExecution -> routeExecution.getEndTime().toLocalDate())
+                .map(RouteExecution::getEndTime)
+                .filter(Objects::nonNull)
+                .map(java.time.LocalDateTime::toLocalDate)
                 .distinct()
                 .sorted(Comparator.reverseOrder())
                 .toList();

--- a/src/main/java/com/fitnessapp/fitapp_api/route/repository/RouteRepository.java
+++ b/src/main/java/com/fitnessapp/fitapp_api/route/repository/RouteRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,6 +17,9 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
     List<Route> findAllByUserEmail(String email);
 
     Optional<Route> findByIdAndUserEmail(Long id, String email);
+
+    // Optimización para Home KPI
+    boolean existsByUser_EmailAndCreatedAtBetween(String email, LocalDateTime start, LocalDateTime end);
 
     // Hard delete
     @Modifying

--- a/src/main/java/com/fitnessapp/fitapp_api/routeexecution/dto/RouteExecutionResponseDTO.java
+++ b/src/main/java/com/fitnessapp/fitapp_api/routeexecution/dto/RouteExecutionResponseDTO.java
@@ -1,6 +1,7 @@
 package com.fitnessapp.fitapp_api.routeexecution.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDateTime;
 
@@ -38,25 +39,28 @@ public record RouteExecutionResponseDTO(
                 description = "Fecha y hora de inicio de la ejecución",
                 example = "2025-11-11T08:30:00"
         )
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") // [Modificado] Asegura formato String ISO
         LocalDateTime startTime,
 
         @Schema(
                 description = "Fecha y hora de la última pausa (si está pausada)",
                 example = "2025-11-11T08:45:00"
         )
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") // [Modificado] Asegura formato String ISO
         LocalDateTime pauseTime,
 
         @Schema(
                 description = "Fecha y hora de finalización",
                 example = "2025-11-11T09:30:00"
         )
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") // [Modificado] Asegura formato String ISO
         LocalDateTime endTime,
 
         @Schema(
                 description = "Tiempo total en segundos que la ejecución estuvo pausada",
                 example = "300"
         )
-        Long totalPausedTime,
+        Long totalPausedTimeSec,
 
         @Schema(
                 description = "Duración total de la ruta en segundos (hora_fin - hora_inicio - tiempo_pausado_total)",

--- a/src/main/java/com/fitnessapp/fitapp_api/routeexecution/mapper/RouteExecutionMapper.java
+++ b/src/main/java/com/fitnessapp/fitapp_api/routeexecution/mapper/RouteExecutionMapper.java
@@ -32,7 +32,8 @@ public interface RouteExecutionMapper {
 
     // --- RESPUESTA ---
     @Mapping(target = "userEmail", source = "user.email")
-    @Mapping(target = "routeId", source = "route.id")
+    @Mapping(target = "routeId", expression = "java(execution.getRoute() != null ? execution.getRoute().getId() : null)")
+    @Mapping(target = "routeName", expression = "java(execution.getRoute() != null ? execution.getRoute().getName() : \"Ruta Eliminada\")")
     RouteExecutionResponseDTO toResponseDto(RouteExecution execution);
 
 }

--- a/src/main/java/com/fitnessapp/fitapp_api/routeexecution/model/RouteExecution.java
+++ b/src/main/java/com/fitnessapp/fitapp_api/routeexecution/model/RouteExecution.java
@@ -5,6 +5,8 @@ import com.fitnessapp.fitapp_api.route.model.Route;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.math.BigDecimal;
@@ -28,6 +30,7 @@ public class RouteExecution {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "route_id", nullable = false, foreignKey = @ForeignKey(name = "fk_route_execution_route"))
+    @NotFound(action = NotFoundAction.IGNORE)
     private Route route;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)


### PR DESCRIPTION
- Corregir nombre de campo en DTO: 'totalPausedTime' a 'totalPausedTimeSec' para arreglar mapeo y salto de tiempo en frontend.
- Blindar RouteExecutionService: Try-catch en cálculo de calorías (evita crash por perfil incompleto) y validación de tiempos no negativos.
- Optimizar HomeService: Reemplazar filtrado en memoria por query eficiente 'exists' y añadir null-checks.
- Mejorar borrado de rutas: Implementar borrado en cascada (hard delete) y manejo seguro de rutas nulas en el Mapper.