### PR TITLE
correccion rutas endpoints route y routeExecution

### DIFF
--- a/src/main/java/com/fitnessapp/fitapp_api/route/controller/RouteController.java
+++ b/src/main/java/com/fitnessapp/fitapp_api/route/controller/RouteController.java
@@ -28,7 +28,7 @@ public class RouteController {
     private final RouteService service;
 
     // ---------------------------------------
-    // GET /api/v1/routes
+    // GET /api/v1/routes/me
     // ---------------------------------------
     @Operation(
             summary = "Listar mis rutas activas",
@@ -48,14 +48,14 @@ public class RouteController {
                     @ApiResponse(responseCode = "401", description = "No autorizado", content = @Content)
             }
     )
-    @GetMapping
+    @GetMapping("/me")
     public ResponseEntity<List<RouteResponseDTO>> getMyRoutes(Principal principal) {
         List<RouteResponseDTO> routes = service.getMyRoutes(principal.getName());
         return ResponseEntity.ok(routes);
     }
 
     // ---------------------------------------
-    // GET /api/v1/routes/{id}
+    // GET /api/v1/routes/me/{id}
     // ---------------------------------------
     @Operation(
             summary = "Mostrar una ruta por su id",
@@ -76,7 +76,7 @@ public class RouteController {
                     @ApiResponse(responseCode = "401", description = "No autorizado", content = @Content)
             }
     )
-    @GetMapping("/{id}")
+    @GetMapping("/me/{id}")
     public ResponseEntity<RouteResponseDTO> getRouteById(@PathVariable Long id
                                                                 ,Principal principal) {
         RouteResponseDTO route = service.getRouteById(id,principal.getName());
@@ -84,7 +84,7 @@ public class RouteController {
     }
 
     // ---------------------------------------
-    // POST /api/v1/routes
+    // POST /api/v1/routes/me
     // ---------------------------------------
     @Operation(
             summary = "Crear nueva ruta",
@@ -118,7 +118,7 @@ public class RouteController {
                     )
             }
     )
-    @PostMapping
+    @PostMapping("/me")
     public ResponseEntity<RouteResponseDTO> createRoute(Principal principal, @Valid @RequestBody RouteRequestDTO body) {
         RouteResponseDTO created = service.createRoute(principal.getName(), body);
         URI location = ServletUriComponentsBuilder
@@ -130,7 +130,7 @@ public class RouteController {
     }
 
     // ---------------------------------------
-    // PUT /api/v1/routes/{id}
+    // PUT /api/v1/routes/me/{id}
     // ---------------------------------------
     @Operation(
             summary = "Actualizar una ruta existente",
@@ -157,7 +157,7 @@ public class RouteController {
                     @ApiResponse(responseCode = "401", description = "No autorizado", content = @Content(mediaType = "application/json"))
             }
     )
-    @PutMapping("/{id}")
+    @PutMapping("/me/{id}")
     public ResponseEntity<RouteResponseDTO> updateRoute(
             Principal principal,
             @PathVariable Long id,
@@ -168,7 +168,7 @@ public class RouteController {
     }
 
     // ---------------------------------------
-    // DELETE /api/v1/routes/{id}
+    // DELETE /api/v1/routes/me/{id}
     // ---------------------------------------
     @Operation(
             summary = "Eliminar una ruta",
@@ -179,7 +179,7 @@ public class RouteController {
                     @ApiResponse(responseCode = "401", description = "No autorizado", content = @Content(mediaType = "application/json"))
             }
     )
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/me/{id}")
     public ResponseEntity<Void> deleteRoute(Principal principal, @PathVariable Long id) {
         service.deleteRoute(principal.getName(), id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/fitnessapp/fitapp_api/routeexecution/controller/RouteExecutionController.java
+++ b/src/main/java/com/fitnessapp/fitapp_api/routeexecution/controller/RouteExecutionController.java
@@ -25,7 +25,7 @@ public class RouteExecutionController {
     private final RouteExecutionService service;
 
     // ---------------------------------------
-    // POST /api/v1/executions/start/{routeId}
+    // POST /api/v1/executions/me/start/{routeId}
     // ---------------------------------------
     @Operation(
             summary = "Iniciar ejecución de una ruta",
@@ -51,7 +51,7 @@ public class RouteExecutionController {
                     @ApiResponse(responseCode = "401", description = "No autorizado", content = @Content)
             }
     )
-    @PostMapping("/start/{routeId}")
+    @PostMapping("/me/start/{routeId}")
     public ResponseEntity<RouteExecutionResponseDTO> startExecution(
             Principal principal,
             @PathVariable Long routeId,
@@ -62,7 +62,7 @@ public class RouteExecutionController {
     }
 
     // ---------------------------------------
-    // POST /api/v1/executions/pause/{executionId}
+    // POST /api/v1/executions/me/pause/{executionId}
     // ---------------------------------------
     @Operation(
             summary = "Pausar ejecución",
@@ -80,7 +80,7 @@ public class RouteExecutionController {
                     @ApiResponse(responseCode = "401", description = "No autorizado", content = @Content)
             }
     )
-    @PostMapping("/pause/{executionId}")
+    @PostMapping("/me/pause/{executionId}")
     public ResponseEntity<RouteExecutionResponseDTO> pauseExecution(
             Principal principal,
             @PathVariable Long executionId
@@ -89,7 +89,7 @@ public class RouteExecutionController {
     }
 
     // ---------------------------------------
-    // POST /api/v1/executions/resume/{executionId}
+    // POST /api/v1/executions/me/resume/{executionId}
     // ---------------------------------------
     @Operation(
             summary = "Reanudar ejecución",
@@ -107,7 +107,7 @@ public class RouteExecutionController {
                     @ApiResponse(responseCode = "401", description = "No autorizado", content = @Content)
             }
     )
-    @PostMapping("/resume/{executionId}")
+    @PostMapping("/me/resume/{executionId}")
     public ResponseEntity<RouteExecutionResponseDTO> resumeExecution(
             Principal principal,
             @PathVariable Long executionId
@@ -116,7 +116,7 @@ public class RouteExecutionController {
     }
 
     // ---------------------------------------
-    // POST /api/v1/executions/finish/{executionId}
+    // POST /api/v1/executions/me/finish/{executionId}
     // ---------------------------------------
     @Operation(
             summary = "Finalizar ejecución",
@@ -142,7 +142,7 @@ public class RouteExecutionController {
                     @ApiResponse(responseCode = "401", description = "No autorizado", content = @Content)
             }
     )
-    @PostMapping("/finish/{executionId}")
+    @PostMapping("/me/finish/{executionId}")
     public ResponseEntity<RouteExecutionResponseDTO> finishExecution(
             Principal principal,
             @PathVariable Long executionId,
@@ -152,7 +152,7 @@ public class RouteExecutionController {
     }
 
     // ---------------------------------------
-    // GET /api/v1/executions
+    // GET /api/v1/executions/me
     // ---------------------------------------
     @Operation(
             summary = "Obtener mis ejecuciones",
@@ -169,7 +169,7 @@ public class RouteExecutionController {
                     @ApiResponse(responseCode = "401", description = "No autorizado", content = @Content)
             }
     )
-    @GetMapping
+    @GetMapping("me")
     public ResponseEntity<List<RouteExecutionResponseDTO>> getMyExecutions(Principal principal) {
         List<RouteExecutionResponseDTO> executions = service.getMyExecutions(principal.getName());
         return ResponseEntity.ok(executions);


### PR DESCRIPTION
# Cambios en las rutas de Routes y RouteExecutions

Este PR actualiza las rutas de los controladores **Routes** y **RouteExecutions** para alinearlas con el diseño acordado en el issue #34.

## Cambios realizados

- Se sustituyen los endpoints basados en IDs directos por rutas bajo el prefijo **`/me`**, indicando que operan sobre los recursos del usuario autenticado.
- Nuevas rutas:

  **Routes**
  - `GET /api/v1/routes/me`
  - `GET /api/v1/routes/me/{id}`
  - `POST /api/v1/routes/me`
  - `PUT /api/v1/routes/me/{id}`
  - `DELETE /api/v1/routes/me/{id}`

  **RouteExecutions**
  - `POST /api/v1/executions/me/start/{routeId}`
  - `POST /api/v1/executions/me/pause/{executionId}`
  - `POST /api/v1/executions/me/resume/{executionId}`
  - `POST /api/v1/executions/me/finish/{executionId}`
  - `GET /api/v1/executions/me`

