### PR TITLE
ci: Implementar Pipeline de CI para Backend (Tests & Build)

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -3,29 +3,53 @@ name: CI/CD Backend - Azure App Service
 on:
   push:
     branches:
-      - main      # Despliegue a PROD
-      - preprod   # Despliegue a PREPROD
+      - main
+      - preprod
+  pull_request:
+    branches: [ main, preprod, dev ]
   workflow_dispatch:
 
 jobs:
-  build-and-deploy:
+  # --- JOB 1: CI (Calidad del Código) ---
+  ci-check:
+    name: Compilación y Tests (Java 21)
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout código
+        uses: actions/checkout@v4
 
-    # Selección automática del entorno
+      - name: Setup Java JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin' # Coincide con la imagen base del Dockerfile
+          cache: 'maven'
+
+      # Ejecutamos los tests aquí porque el Dockerfile tiene "-DskipTests"
+      # Si esto falla, no pasamos al despliegue.
+      - name: Ejecutar Tests Unitarios
+        run: mvn test
+
+  # --- JOB 2: DESPLIEGUE ---
+  build-and-deploy:
+    name: Desplegar a Azure
+    runs-on: ubuntu-latest
+    needs: ci-check
+
+    # Solo despliega si el CI pasó y es un push a main/preprod
+    if: success() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+
     environment: ${{ github.ref == 'refs/heads/main' && 'prod' || 'preprod' }}
 
     steps:
-      # 1. Descargar código
       - name: Checkout del repositorio
         uses: actions/checkout@v4
 
-      # 2. Login en Azure
       - name: 'Login en Azure'
         uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      # 3. Login en ACR
       - name: 'Login en Azure Container Registry'
         uses: azure/docker-login@v1
         with:
@@ -33,21 +57,19 @@ jobs:
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
 
-      # 4. Build & Push
+      # Aquí Docker volverá a compilar usando el Dockerfile (Multistage build)
+      # Esto garantiza que despliega en un entorno limpio e idéntico al de producción.
       - name: Construir y subir la imagen Docker
         run: |
           docker build . -t ${{ secrets.ACR_LOGIN_SERVER }}/fitapp-backend:${{ github.sha }}
           docker push ${{ secrets.ACR_LOGIN_SERVER }}/fitapp-backend:${{ github.sha }}
 
-      # 5. Desplegar
-      # VARIABLE 'APP_NAME' para el nombre del recurso al cual desplegamos, según el entorno/rama
       - name: 'Desplegar en Azure App Service'
         uses: azure/webapps-deploy@v3
         with:
           app-name: ${{ vars.APP_NAME }}
           images: '${{ secrets.ACR_LOGIN_SERVER }}/fitapp-backend:${{ github.sha }}'
 
-      # 6. Logout
       - name: Logout de Azure
         if: always()
         run: |


### PR DESCRIPTION
Se ha añadido la etapa de **Integración Continua (CI)** al workflow del Backend.
Hasta ahora, el pipeline solo hacía el despliegue (CD). Con este cambio, aseguramos que ningún código llegue a Azure sin pasar antes por la compilación y los tests unitarios.

Resolves: #69 

## CHANGELOG
### ⚙️ Configuración CI/CD
* **Nuevo Job `ci-check`:**
    * Instala **Java 21** (Temurin).
    * Ejecuta `mvn test` para validar la lógica.
* **Actualización `build-and-deploy`:**
    * Ahora depende de que `ci-check` termine exitosamente (`needs: ci-check`).
    * Se mantiene la lógica de construcción con Docker (multistage).

## CHECKLIST
- [x] El workflow usa la misma versión de Java que el Dockerfile (Java 21).
- [x] Se han configurado los triggers para `pull_request` en dev/main.
- [x] El despliegue a Azure sigue funcionando si los tests pasan.